### PR TITLE
Enables watcher to handle unexpected response.

### DIFF
--- a/src/watcher.coffee
+++ b/src/watcher.coffee
@@ -25,10 +25,12 @@ class Watcher extends EventEmitter
 			@index = val.index + 1
 			@emit 'change', val
 			@_watch()
-
-		if err isnt null
+		else if err isnt null
 			@emit 'reconnect', { error: err, reconnectcount: @retryAttempts }
 			@_retry()
+		else
+			@emit 'error', "Received unexpected response '#{val}'"
+			@_watch()
 
 	_retry: () =>
 		setTimeout @_watch, 500 * @retryAttempts


### PR DESCRIPTION
The response data might not contain an index parameter for any reason, or even might not be an object. In that case the watcher would not recognize this and would not continue watching.
