### PR TITLE
Using correct Index in Watcher

### DIFF
--- a/src/watcher.coffee
+++ b/src/watcher.coffee
@@ -28,7 +28,7 @@ class Watcher extends EventEmitter
 
 		else if val? and headers?['x-etcd-index']?
 			@retryAttempts = 0
-			@index = parseInt(val.node.modifiedIndex) + 1
+			@index = val.node.modifiedIndex + 1
 			@emit 'change', val, headers
 			@emit val.action, val, headers if val.action?
 			@_watch()


### PR DESCRIPTION
`Watcher.coffee` used the `x-etcd-index` header to find the next changeset in etcd.
`x-etcd-index` is used to reference to the [current/latest index of this key](https://github.com/coreos/etcd/blob/master/Documentation/api.md#response-headers). It is possible that other changes are between the index of the key currently fetched and the index of the latest value of this key. This could lead to missing events.

Therefore its better to use the `modifiedIndex` of the node.
