### PR TITLE
Creating in-order keys

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -17,7 +17,8 @@ class Etcd
 	set: (key, value, options, callback) ->
 		[options, callback] = @_argParser options, callback
 		opt = @_prepareOpts ("keys/" + @_stripSlashPrefix key), "/v2", value, options
-		@_redirectHandler request.put, opt, @_responseHandler callback
+		requestMethod = if options?.method is 'post' then request.post else request.put
+		@_redirectHandler requestMethod, opt, @_responseHandler callback
 
 	# Get value of key
 	# Usage:


### PR DESCRIPTION
Hey there.

etcd allows to create in [order keys](https://github.com/coreos/etcd/blob/master/Documentation/api.md#atomically-creating-in-order-keys) using a post method.

I needed this feature, so I extended the `set` method to take an optional `method` parameter as a option

Do you prefer to have a separate method to create in-order keys or do you like the approach with the `set` function?
Before I continue to write code, I would discuss with you what method you prefer.
