### PR TITLE
Handle errors properly

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -34,7 +34,7 @@ class Client
 
 	_handleResponse: (err, resp, body, callback) ->
 		if err or resp.statusCode isnt 200
-			callback body, "", (resp.headers or {})
+			callback body, "", (resp?.headers or {})
 		else
 			callback err, body, (resp.headers or {})
 


### PR DESCRIPTION
When an err is returned such as as unreachable host (etcd is down), the resp object will be null. Previously, this would throw a `Cannot read property 'headers' of undefined` expection, but not it should handle things gracefully.
