### PR TITLE
Allow watchers to be stopped

### DIFF
--- a/src/watcher.coffee
+++ b/src/watcher.coffee
@@ -14,11 +14,14 @@ class Watcher extends EventEmitter
 		@retryAttempts = 0
 		@_watch()
 
+	stop: () =>
+		@request.abort()
+
 	_watch: () =>
 		if @index is null
-			@etcd.watch @key, @options, @_respHandler
+			@request = @etcd.watch @key, @options, @_respHandler
 		else
-			@etcd.watchIndex @key, @index, @options, @_respHandler
+			@request = @etcd.watchIndex @key, @index, @options, @_respHandler
 
 	_respHandler: (err, val, headers) =>
 


### PR DESCRIPTION
I was trying to figure out how to cleanly stop watchers, but it seemed impossible (perhaps I'm mistaken).

This change makes it keeps track of the active watch request and provides a `stop` function. It doesn't include a test ("it works for me") because I wasn't sure how to best implement and mock things - if you have advice I can try to make the test, too.

Thanks for the module!
