### PR TITLE
Fix synchronous code when servers fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-etcd",
-  "version": "3.0.2",
+  "version": "4.0.1",
   "description": "etcd library for node.js (etcd v2 api)",
   "licenses": [
     {


### PR DESCRIPTION
In the case that the etcd servers were failing, the code was creating multiple sync loops which was bad. This change fixes that and a problem with the syncRespHandler callback when _multiserverHelper was called multiple times.