### PR TITLE
Fix for node 4.0.0 and iojs 3.3.0, closes #43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - "iojs"
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
+compiler:
+  - gcc
+  - clang
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 sudo: false
+before_script:
+  - "npm explore npm -g -- npm install node-gyp@latest"
 node_js:
   - "iojs-v3.2.0"
   - "iojs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 sudo: false
 node_js:
+  - "iojs-v3.2.0"
   - "iojs"
+  - "4.0.0"
   - "0.12"
   - "0.11"
   - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 sudo: false
-before_script:
-  - "npm explore npm -g -- npm install node-gyp@latest"
 node_js:
   - "iojs-v3.2.0"
   - "iojs"
@@ -9,4 +7,13 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
-
+install:
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ node_js:
   - "0.11"
   - "0.10"
 env:
-  - CXX="g++-4.8"
-  - CC="gcc-4.8"
+  - CXX="g++-4.8" CC="gcc-4.8"
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
-compiler:
-  - gcc
-  - clang
-install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-  - npm install
+env:
+  - CXX="g++-4.8"
+  - CC="gcc-4.8"
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js:
   - "0.10"
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - npm install
 addons:
   apt:
     sources:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "underscore": "~1.8.2",
     "request": "~2.60.0",
-    "deasync": "~0.0.10"
+    "deasync": "~0.1.1"
   },
   "devDependencies": {
     "coffee-script": "~1.9.1",


### PR DESCRIPTION
- Updated deasync to v0.1.1
- Forced travis-ci to use g++-4.8 (travis runs on ubuntu 12.04), compiler was too old for nodejs 4.0.0