### PR TITLE
Update deasync

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch": "node_modules/.bin/mocha --compilers coffee:coffee-script/register --watch"
   },
   "dependencies": {
-    "deasync": "0.1.1",
+    "deasync": "0.1.7",
     "request": "2.60.0",
     "underscore": "1.8.2",
     "url-parse": "1.0.5"


### PR DESCRIPTION
If node-etcd was installed with an older version of node (e.g. 0.10.x), but *run* with a newer version of node (e.g. 4.x), it caused a binding failure due to that version of deasync being compiled with an older version of node / nan.

I think this resolves #47.

It's a minor change, but if environments are not perfectly synced up, this could be a strange bug. I'm not sure how to bump the version for npm (or if I can even do that).