### PR TITLE
Fix vulnerabilities and add support for node 9 & 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
 sudo: false
 node_js:
-  - "iojs"
+  - "10"
+  - "9"
+  - "8"
   - "7"
   - "6"
-  - "5"
-  - "4"
 env:
   - CXX="g++-4.8" CC="gcc-4.8"
 addons:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ A nodejs library for [ETCD v2](https://coreos.com/etcd/docs/latest/v2/api.html),
 
 ## Install
 
-For nodes >= 4.x:
+For nodes >= 6.x:
 
 ```
 $ npm install node-etcd
+```
+
+For nodes 4.x <= node < 6.x:
+
+```
+$ npm install node-etcd@6
 ```
 
 For 0.10.x <= nodejs <= 4.x and iojs:
@@ -27,6 +33,9 @@ $ npm install node-etcd@3.0.2
 ```
 
 ## Changes
+- 7.0.0
+  - Fixing vulnerabilities
+  - Drop support for nodejs version 4 &4
 - 6.0.0
   - Migrate from underscore to lodash for performance / @derektbrown
   - Updated package versions / @derektbrown

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "dependencies": {
-    "deasync": "0.1.10",
+    "deasync": "^0.1.13",
     "lodash": "^4.17.10",
     "request": "^2.87.0",
     "url-parse": "^1.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-etcd",
-  "version": "6.0.2",
+  "version": "7.0.0",
   "description": "etcd library for node.js (etcd v2 api)",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
     }
   ],
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 6.0.0"
   },
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -59,16 +59,16 @@
   },
   "dependencies": {
     "deasync": "0.1.10",
-    "lodash": "4.17.4",
-    "request": "2.81.0",
-    "url-parse": "1.0.5"
+    "lodash": "^4.17.10",
+    "request": "^2.87.0",
+    "url-parse": "^1.4.3"
   },
   "devDependencies": {
     "coffee-coverage": "2.0.1",
     "coffee-script": "1.12.7",
-    "mocha": "3.5.0",
-    "nock": "9.0.14",
-    "nyc": "11.1.0",
+    "mocha": "^4.0.0",
+    "nock": "^9.4.4",
+    "nyc": "^12.0.0",
     "should": "11.2.1",
     "simple-mock": "0.8.0"
   },

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -248,8 +248,8 @@ class Etcd
   _cleanHostList: (hosts) ->
     hostlist = if _.isArray(hosts) then hosts else [hosts]
     hostlist.map (host) ->
+      host = 'http://' + host if host.indexOf('http') is -1
       url = new URL(host)
-      url.set 'protocol', 'http:' if url.protocol is ''
       url.href.replace /\/$/, "" # Trailing slash
 
 


### PR DESCRIPTION
The dependencies `lodash`, `request` and `url-parse` are having vulnerabilities in the used version.
I updated them to the newest version.

There was a breaking change in the `url-parse`: It cant parse an url without protocol.
I also fixed this one.

Since node 4 & 5 is now unmaintained i increased the minimum version to 6 and fixed the issues with node 9 & 10
@stianeikeland Is this fine with you?